### PR TITLE
Task 9 (Docker and AWS Elastic Beanstalk, Updating the Frontend Application)

### DIFF
--- a/frontend/src/components/MainLayout/components/Header.tsx
+++ b/frontend/src/components/MainLayout/components/Header.tsx
@@ -65,14 +65,14 @@ export default function Header({ themeSwitch, isDarkMode }: HeaderProps) {
         <ListItemIcon>
           <LogoutIcon fontSize="small" />
         </ListItemIcon>
-        <ListItemText>Logout (Task 8)</ListItemText>
+        <ListItemText>Logout (Task 8|9)</ListItemText>
       </MenuItem>
     ) : (
       <MenuItem component={RouterLink} to="/signin" onClick={() => handleAuthMenuClose()}>
         <ListItemIcon>
           <LoginIcon fontSize="small" />
         </ListItemIcon>
-        <ListItemText>Login (Task 8)</ListItemText>
+        <ListItemText>Login (Task 8|9)</ListItemText>
       </MenuItem>
     );
   };

--- a/frontend/src/constants/apiPaths.ts
+++ b/frontend/src/constants/apiPaths.ts
@@ -1,15 +1,15 @@
 const apiUrl = 'https://xcunh9a844.execute-api.eu-north-1.amazonaws.com/dev';
 
+// Cart Service API (cloudfront for elasticbeanstalk)
+const apiCartCludFrontEBSUrl = 'https://d1wr58fh208zzd.cloudfront.net';
+
 const API_PATHS = {
   product: apiUrl,
   orderMock: apiUrl,
   import: 'https://387mfqhlx3.execute-api.eu-north-1.amazonaws.com/dev',
   bff: apiUrl,
-  cart: 'https://ioj2n6t5s6frqgkdq2rogcbvim0mkiot.lambda-url.eu-north-1.on.aws/api',
-  //cart: 'https://37pfsxymcyin36rhcpcnpwzwpe0fwelv.lambda-url.eu-north-1.on.aws/api', // second valid url)))
-  //cart: 'http://localhost:4000/api',
-  order: 'https://ioj2n6t5s6frqgkdq2rogcbvim0mkiot.lambda-url.eu-north-1.on.aws/api/profile/cart',
-  // order: 'https://37pfsxymcyin36rhcpcnpwzwpe0fwelv.lambda-url.eu-north-1.on.aws/api/profile/cart',
+  cart: `${apiCartCludFrontEBSUrl}/api`,
+  order: `${apiCartCludFrontEBSUrl}/api/profile/cart`,
   subscribe: 'https://xcunh9a844.execute-api.eu-north-1.amazonaws.com/dev',
 };
 


### PR DESCRIPTION
## Task 9 (Docker and AWS Elastic Beanstalk, Updating the Frontend Application)

The application has been fully updated to meet the requirements of task [task](https://github.com/rolling-scopes-school/aws/blob/main/aws-developer/08_integration_with_sql_database/task.md).

### Deploy
> **CloudFront:** https://db5i175ksp8cp.cloudfront.net
> **CloudFront with Route 53:** https://sunsundr.store

### Link to BE (backend) PR
> **Backend:** [PR](https://github.com/SunSundr/nodejs-aws-shop-backend/pull/7)

## Key Changes:

The access path to cart-service in `frontend/src/constants/apiPaths.ts` has been updated. It now uses CloudFront connected to the AWS Elastic Beanstalk image with the deployed Nest application, instead of the Lambda function. All functionality remains the same.

## Application testing:

1.  **Registration:**

    *   To test the application, a simple registration is required (accessible via the Login (Task 8|9) and Logout (Task 8|9) menu items).
    ![image](https://github.com/user-attachments/assets/9dd8babf-166f-491d-ac9d-afa361904c2d)
    ![image](https://github.com/user-attachments/assets/7b311148-9920-437c-882d-8c553c315305)
    ![image](https://github.com/user-attachments/assets/85f2fbc2-7a80-4e95-8873-ea348f6f05f8)

    *   Cognito authorization is still available as a separate menu item. **Note these are two different registrations**.
    > You can register as a new user, but you will not have admin privileges and the admin pages will be inaccessible.
    > To gain admin test access, use the following credentials:
    >
    > **Email:**  `admin@sunsundr.store`
    > **Password:** `ADMIN:1E7f2la1k18y`
    >
    > *Due to significant discrepancies between the assignment requirements for the `orders` table (PostgreSQL) and the original implementation of order management (which uses a different data type), mock data is currently being used for display `orders`. I mentioned this in [Discord](https://discord.com/channels/1018779355155013693/1018943744898252830/1358807069699866685).*

    *   Eventually, only Cognito registration will remain. Currently, registration via Cognito is not integrated into the Lambda function where the Nest application is deployed.

2.  **Cart Functionality Enabled After `Login (Task 8|9)`:**

    *   After using `Login (Task 8|9)`, you can add and remove products from the cart.  
    ![image](https://github.com/user-attachments/assets/28087737-e7f8-4d72-8851-783f73c6a0b0)
    *   You can view your cart and submit an order. The cart isn't deleted from the database after placing an order, but it becomes unavailable for adding more items.
    ![image](https://github.com/user-attachments/assets/4b213da0-6ad1-48a9-8331-fe496dca26d5)

